### PR TITLE
Fix dialog bugs & Rebug crash on PHP <8.1

### DIFF
--- a/models/Rehike/Debugger/MYtWalker.php
+++ b/models/Rehike/Debugger/MYtWalker.php
@@ -69,9 +69,19 @@ class MYtWalker extends MTabContent
                 $key = $reflection->getName();
 
                 if ($value instanceof ReflectionProperty)
+                {
+                    /*
+                     * PATCH (dcooper): Required before PHP 8.1, else a ReflectionException is thrown
+                     * upon trying to access the contents of a protected or private property.
+                    */
+                    $reflection->setAccessible(true);
+
                     $value = $reflection->getValue($obj);
+                }
                 else
+                {
                     $value = "[function]";
+                }
 
                 if ($reflection->isPrivate() || $reflection->isProtected())
                 {

--- a/template/hitchhiker/core/meta.twig
+++ b/template/hitchhiker/core/meta.twig
@@ -43,10 +43,6 @@
         margin: 0 5px;
     }
 
-    body.yt-dialog-active {
-        overflow: visible;
-    }
-
     /* Player overwrites this for some reason and it hides channel upsell video show more link */
     .yt-uix-expander-ellipsis.yt-ui-ellipsis-10::before {
         top: 0;
@@ -58,10 +54,6 @@
 </style>
 {%- if yt.config.hhCSSFixes -%}
 <style id="hh-css-fix">
-    html {
-        overflow-y: scroll;
-    }
-
     #watch-description-text {
         padding-top: 4px;
     }

--- a/template/hitchhiker/rehike/debugger/js/util.js.twig
+++ b/template/hitchhiker/rehike/debugger/js/util.js.twig
@@ -104,6 +104,15 @@ rebug.util.scrollLock.enable = function()
     // Finally, freeze the body itself in place.
     var bodyInfo = rebug.util.scrollLock.getElementInfo(document.body);
     rebug.util.scrollLock._bodyInfo = bodyInfo;
+
+    // PATCH (dcooper): Required to not jump around visually if not already set on <html>
+    document.documentElement.setAttribute(
+        "style",
+        (
+            (document.body.getAttribute("style") || "") +
+            ";overflow-y:scroll"
+        )
+    );
   
     document.body.setAttribute(
         "style",
@@ -128,6 +137,8 @@ rebug.util.scrollLock.disable = function()
     // Undo body changes (this must be done first to avoid
     // conflicts with children changes)
     var bodyInfo = rebug.util.scrollLock._bodyInfo;
+
+    document.documentElement.removeAttribute("style");
 
     if (bodyInfo.hasPreviousInlineStyle)
     {

--- a/template/hitchhiker/rehike/debugger/lightbox_main.twig
+++ b/template/hitchhiker/rehike/debugger/lightbox_main.twig
@@ -7,7 +7,22 @@
 #}
 
 {%- macro dialog(data) -%}
-    <div class="yt-dialog preserve-players rebug-base-dialog">
+    {# 
+        PATCH (dcooper): **This cannot have the yt-dialog class**, as it causes a bug in common.js at
+        yt.ui.Dialog.prototype.isAnyDialogDisplayed_() --> goog.dom.getElementsByClass("yt-dialog")
+
+        This bug breaks standard closing behaviour as implemented by YouTube's source code. The check essentially
+        recognises the Rebug dialog container as a parent dialog to any further open dialogs, such as the subscription
+        preferences one, and, as such, prevents the dialog from fully closing. This leaves the background sitting behind,
+        with all references disposed of by the UIX Overlay class upon its understanding that the bound dialog had closed properly,
+        therefore leaving it to the user to manually remove the dialog background scrim using Inspect Element or refreshing
+        the page.
+
+        Since there are no stylistic drawbacks to this change, I've opted to simply update Rebug to remove this class
+        and completely fix the behaviour, which has been a thorn in the side of Rehike developers and users alike for
+        months now.
+    #}
+    <div class="rebug-base-dialog">
         <div class="yt-dialog-base">
             <span class="yt-dialog-align"></span>
             <div role="dialog" tabindex="0" class="yt-dialog-fg yt-uix-overlay-primary yt-uix-overlay">


### PR DESCRIPTION
# Rebug crash

PHP 8.1 changed the behaviour of `ReflectionProperty` to allow reading protected/private properties without any further change. In previous versions, a method `setAccessible(true)` had to be called in order to give permission to access the value. Since this triggered an uncaught exception, the bug not only broke Rebug, but Rehike as a whole in certain cases on older PHP versions.

# Dialog bug fixes

Many of Rehike's additional modifications, including the CSS patches and Rebug, had caused very unexpected behaviour of dialogs when contrasted with an unmodified archive. In order to correct these, the Rebug client had to be modified slightly to prevent graphical glitches with the broader CSS changes.

The primary issue issue with dialogs - the inability to close them (as reported in #167 among other places) - was caused by Rebug itself, in a very innocuous way. A method on YouTube's Dialog class performed a check for other dialogs opened.

```js
goog.dom.getElementsByClass(yt.ui.Dialog.DIALOG_CONTAINER_CLASS [["yt-dialog"]])
yt.ui.Dialog.prototype.isAnyDialogDisplayed_()
```
![image](https://user-images.githubusercontent.com/28045018/201536575-65ffa2fa-0850-4cf5-9298-131a4ac384f2.png)

As Rebug implemented its dialog container as a simple `yt-dialog` with no special properties to denote it as hidden, this confused this function, which caused it to recognise it as open. Thus, any further opened dialogs were regarded as children of the Rebug container. In the event of a child dialog being opened, the `yt-dialog-bg` background scrim doesn't get removed, thus leaving it there for eternity. Also, since the `yt.uix.Overlay` was closed, its global handlers would already be closed, leaving no references to the background for it. No matter what, it was left to the user to manually remove the element via inspect element or refreshing the page.

In addition, a display glitch would occur with dialogs as a result of a custom CSS patch to always display the scrollbar. Since this explicitly set `overflow-y: scroll` on the parent, this caused a bug whereby the body would remain scrollable and the page content would be oddly cropped. **The below image shows this behaviour.** Removing the property corrected display, at the expense of requiring a Rebug patch (its `scrollLock` functionality relied on this property) and small display bugs inherited from hitchhiker if the view was too short to scroll.

![image](https://user-images.githubusercontent.com/28045018/201536470-6c85df66-4495-4148-b0ef-536eb6403903.png)
