### PR TITLE
Fix onGet function of get_live_chat.php not matching HitchhikerContro…

### DIFF
--- a/controllers/special/get_live_chat.php
+++ b/controllers/special/get_live_chat.php
@@ -15,7 +15,7 @@ return new class extends HitchhikerController
     public const YTCFG_REGEX = "/ytcfg\.set\(({.*?})\);/";
     public bool $useTemplate = false;
 
-    public function onGet(YtApp &$yt, RequestMetadata $request): void
+    public function onGet(YtApp $yt, RequestMetadata $request): void
     {
         async(function() use (&$yt, &$request) {
             $chatData = yield SimpleFunnel::funnelCurrentPage();

--- a/template/hitchhiker/common/uix/load_more_button.twig
+++ b/template/hitchhiker/common/uix/load_more_button.twig
@@ -1,7 +1,7 @@
 {% macro render(continuation, target, autoload = false, endpoint = "browse_ajax") %}
 <button class="yt-uix-button yt-uix-button-size-default yt-uix-button-default load-more-button yt-uix-load-more browse-items-load-more-button yt-uix-sessionlink yt-uix-load-more-error {{ autoload ? "scrolldetect" }}"
         aria-label="Load more" onclick=";return false;"
-        data-sessionlink-target="/{{ endpoint }}action_continuation=1&amp;continuation={{ continuation }}&amp;direct_render=1&amp;target_id={{ target }}"
+        data-sessionlink-target="/{{ endpoint }}?action_continuation=1&amp;continuation={{ continuation }}&amp;direct_render=1&amp;target_id={{ target }}"
         data-uix-load-more-href="/{{ endpoint }}?action_continuation=1&amp;continuation={{ continuation }}&amp;direct_render=1&amp;target_id={{ target }}"
         data-uix-load-more-target-id="{{ target }}">
     <span class="yt-uix-button-content">


### PR DESCRIPTION
…ller, thus throwing a compile error

Would throw this before:

    Error type: PHP compiler error (E_COMPILE_ERROR)
    File: rehike://controllers/special/get_live_chat.php:18
    Message: Declaration of Rehike\Controller\core\HitchhikerController@anonymous::onGet(Rehike\YtApp &$yt, Rehike\ControllerV2\RequestMetadata $request): void must be compatible with Rehike\Controller\core\HitchhikerController::onGet(Rehike\YtApp $yt, Rehike\ControllerV2\RequestMetadata $request): void
