### PR TITLE
Experimental 2022 and 2020 player option

### DIFF
--- a/controllers/watch.php
+++ b/controllers/watch.php
@@ -242,13 +242,9 @@ return new class extends NirvanaController {
         ])->then(function ($responses) use ($yt) {
             $nextResponse = $responses["next"]->getJson();
             $playerResponse = $responses["player"]->getJson();
-            try{                
+            if (false === Config::getConfigProp("experiments.encryptedStreams")){
                 $storyboardResponse = $responses["storyboard"]->getJson();
                 $playerResponse->storyboards = $storyboardResponse->storyboards;
-            }
-            catch (GeneralException $e)
-            {
-                $storyboardResponse = (object) [];
             }
             try
             {

--- a/controllers/watch.php
+++ b/controllers/watch.php
@@ -75,7 +75,7 @@ return new class extends NirvanaController {
         ];
 
         // Content restriction
-        if (isset($_GET["has_verified"]) && ($_GET["has_verified"] == "1" || $_GET["has_verified"] == true))
+        if (isset($_GET["has_verified"]) && ($_GET["has_verified"] == "1" || $_GET["has_verified"] == true) or false === Config::getConfigProp("experiments.encryptedStreams"))
         {
             $sharedRequestParams += ["racyCheckOk" => true];
             $sharedRequestParams += ["contentCheckOk" => true];
@@ -151,25 +151,71 @@ return new class extends NirvanaController {
         // Unlike Polymer, Hitchhiker had all of the player data already
         // available in the initial response. So an additional player request
         // is used.
-        $playerRequest = Network::innertubeRequest(
-            "player",
-            [
-                "playbackContext" => [
-                    'contentPlaybackContext' => (object) [
-                        'autoCaptionsDefaultOn' => false,
-                        'autonavState' => 'STATE_OFF',
-                        'html5Preference' => 'HTML5_PREF_WANTS',
-                        'lactMilliseconds' => '13407',
-                        'mdxContext' => (object) [],
-                        'playerHeightPixels' => 1080,
-                        'playerWidthPixels' => 1920,
-                        'signatureTimestamp' => $yt->playerConfig->signatureTimestamp
-                    ]   
-                ],
-                "startTimeSecs" => $startTime ?? 0,
-                "params" => $yt->playerParams
-            ] + $sharedRequestParams
-        );
+        if (false === Config::getConfigProp("experiments.encryptedStreams")){
+            $playerRequest = Network::innertubeRequest(
+                "player",
+                [
+                    "playbackContext" => [
+                        'contentPlaybackContext' => (object) [
+                            'autoCaptionsDefaultOn' => false,
+                            'autonavState' => 'STATE_OFF',
+                            'html5Preference' => 'HTML5_PREF_WANTS',
+                            'lactMilliseconds' => '13407',
+                            'mdxContext' => (object) [],
+                            'playerHeightPixels' => 1080,
+                            'playerWidthPixels' => 1920,
+                            'signatureTimestamp' => $yt->playerConfig->signatureTimestamp
+                        ]   
+                    ],
+                    "startTimeSecs" => $startTime ?? 0,
+                    "params" => 'CgIQBg=='
+                ] + $sharedRequestParams,
+                    clientName: "ANDROID",
+                    clientVersion: "16.02.00"
+            );
+            $storyboardRequest = Network::innertubeRequest(
+                "player",
+                [
+                    "playbackContext" => [
+                        'contentPlaybackContext' => (object) [
+                            'autoCaptionsDefaultOn' => false,
+                            'autonavState' => 'STATE_OFF',
+                            'html5Preference' => 'HTML5_PREF_WANTS',
+                            'lactMilliseconds' => '13407',
+                            'mdxContext' => (object) [],
+                            'playerHeightPixels' => 1080,
+                            'playerWidthPixels' => 1920,
+                            'signatureTimestamp' => $yt->playerConfig->signatureTimestamp
+                        ]
+                    ],
+                    "startTimeSecs" => $startTime ?? 0
+                ] + $sharedRequestParams,
+                clientName: "XBOXONEGUIDE",
+                clientVersion: "1.0"
+            );
+        }
+        else{
+            $playerRequest = Network::innertubeRequest(
+                "player",
+                [
+                    "playbackContext" => [
+                        'contentPlaybackContext' => (object) [
+                            'autoCaptionsDefaultOn' => false,
+                            'autonavState' => 'STATE_OFF',
+                            'html5Preference' => 'HTML5_PREF_WANTS',
+                            'lactMilliseconds' => '13407',
+                            'mdxContext' => (object) [],
+                            'playerHeightPixels' => 1080,
+                            'playerWidthPixels' => 1920,
+                            'signatureTimestamp' => $yt->playerConfig->signatureTimestamp
+                        ]   
+                    ],
+                    "startTimeSecs" => $startTime ?? 0,
+                    "params" => $yt->playerParams
+                ] + $sharedRequestParams
+            );
+            $storyboardRequest = new Promise(fn($r) => $r());
+        }
 
         /**
          * Determine whether or not to use the Return YouTube Dislike
@@ -189,13 +235,21 @@ return new class extends NirvanaController {
         }
 
         Promise::all([
-            "next"   => $nextRequest,
-            "player" => $playerRequest,
-            "ryd"    => $rydRequest
+            "next"       => $nextRequest,
+            "player"     => $playerRequest,
+            "ryd"        => $rydRequest,
+            "storyboard" => $storyboardRequest
         ])->then(function ($responses) use ($yt) {
             $nextResponse = $responses["next"]->getJson();
             $playerResponse = $responses["player"]->getJson();
-
+            try{                
+                $storyboardResponse = $responses["storyboard"]->getJson();
+                $playerResponse->storyboards = $storyboardResponse->storyboards;
+            }
+            catch (GeneralException $e)
+            {
+                $storyboardResponse = (object) [];
+            }
             try
             {
                 $rydResponse = $responses["ryd"]?->getJson() ?? (object)[];

--- a/i18n/en-US/rehike/config.i18n
+++ b/i18n/en-US/rehike/config.i18n
@@ -82,7 +82,18 @@ props:
         Makes the home page signed out. This is a workaround for YouTube 
         blocking homepage access if you have watch history disabled 
         (2023/08/18).
-  
+    olderPlayers:
+      title: "Use older video players (delete player_cache.json!):"
+      values:
+        CURRENT: "Latest player"
+        SQUARE: "2022 - Square edges, old storyboard"
+        SMALLER: "2020 - Smaller UI"
+    encryptedStreams:
+      title: "Use encrypted video streams"
+      subtitle: >
+        Required for proper functioning of older players! Uses ANDROID
+        for requests to get video streams without encryption.
+
   advanced:
     enableDebugger:
       title: "Enable the debugger"

--- a/modules/Rehike/ConfigDefinitions.php
+++ b/modules/Rehike/ConfigDefinitions.php
@@ -39,7 +39,7 @@ class ConfigDefinitions
             "experiments" => [
                 "useSignInV2" => new BoolProp(false),
                 "disableSignInOnHome" => new BoolProp(false),
-                "olderPlayers" => new EnumProp(CURRENT),
+                "olderPlayers" => new EnumProp("CURRENT"),
                 "encryptedStreams" => new BoolProp(true)
             ],
             "advanced" => [

--- a/modules/Rehike/ConfigDefinitions.php
+++ b/modules/Rehike/ConfigDefinitions.php
@@ -38,7 +38,9 @@ class ConfigDefinitions
             ],
             "experiments" => [
                 "useSignInV2" => new BoolProp(false),
-                "disableSignInOnHome" => new BoolProp(false)
+                "disableSignInOnHome" => new BoolProp(false),
+                "olderPlayers" => new EnumProp(CURRENT),
+                "encryptedStreams" => new BoolProp(true)
             ],
             "advanced" => [
                 "enableDebugger" => new BoolProp(false)

--- a/modules/Rehike/Player/PlayerUpdater.php
+++ b/modules/Rehike/Player/PlayerUpdater.php
@@ -69,7 +69,7 @@ class PlayerUpdater
             $currentlyusedCssUrl = "/s/player/c57c113c/www-player.css";
         }
         else {
-            $currentlyUsedJsUrl = "/yts/jsbin/player_ias-vfl1Ng2HU/de_DE/base.js";
+            $currentlyUsedJsUrl = "/yts/jsbin/player_ias-vfl1Ng2HU/en_US/base.js";
             $currentlyusedCssUrl = "/yts/cssbin/player-vflfo9Nwd/www-player-webp.css";
         };
 

--- a/modules/Rehike/Player/PlayerUpdater.php
+++ b/modules/Rehike/Player/PlayerUpdater.php
@@ -1,6 +1,8 @@
 <?php
 namespace Rehike\Player;
 
+use Rehike\ConfigManager\Config;
+
 use Rehike\Player\Exception\UpdaterException;
 
 /**

--- a/modules/Rehike/Player/PlayerUpdater.php
+++ b/modules/Rehike/Player/PlayerUpdater.php
@@ -60,11 +60,11 @@ class PlayerUpdater
 
         $sts = self::extractSts($js);
 
-        if ("CURRENT" === Config::getConfigProp("experiments.olderplayers")){
+        if ("CURRENT" === Config::getConfigProp("experiments.olderpPlayers")){
             $currentlyUsedJsUrl = $jsUrl;
             $currentlyusedCssUrl = $cssUrl;
         }
-        elseif ("SQUARE" === Config::getConfigProp("experiments.olderplayers")){
+        elseif ("SQUARE" === Config::getConfigProp("experiments.olderPlayers")){
             $currentlyUsedJsUrl = "/s/player/c57c113c/player_ias.vflset/en_US/base.js";
             $currentlyusedCssUrl = "/s/player/c57c113c/www-player.css";
         }

--- a/modules/Rehike/Player/PlayerUpdater.php
+++ b/modules/Rehike/Player/PlayerUpdater.php
@@ -60,7 +60,7 @@ class PlayerUpdater
 
         $sts = self::extractSts($js);
 
-        if ("CURRENT" === Config::getConfigProp("experiments.olderpPlayers")){
+        if ("CURRENT" === Config::getConfigProp("experiments.olderPlayers")){
             $currentlyUsedJsUrl = $jsUrl;
             $currentlyusedCssUrl = $cssUrl;
         }

--- a/modules/Rehike/Player/PlayerUpdater.php
+++ b/modules/Rehike/Player/PlayerUpdater.php
@@ -60,10 +60,23 @@ class PlayerUpdater
 
         $sts = self::extractSts($js);
 
+        if ("CURRENT" === Config::getConfigProp("experiments.olderplayers")){
+            $currentlyUsedJsUrl = $jsUrl;
+            $currentlyusedCssUrl = $cssUrl;
+        }
+        elseif ("SQUARE" === Config::getConfigProp("experiments.olderplayers")){
+            $currentlyUsedJsUrl = "/s/player/c57c113c/player_ias.vflset/en_US/base.js";
+            $currentlyusedCssUrl = "/s/player/c57c113c/www-player.css";
+        }
+        else {
+            $currentlyUsedJsUrl = "/yts/jsbin/player_ias-vfl1Ng2HU/de_DE/base.js";
+            $currentlyusedCssUrl = "/yts/cssbin/player-vflfo9Nwd/www-player-webp.css";
+        };
+
         // Pack these up and return:
         return (object)[
-            "baseJsUrl" => $jsUrl,
-            "baseCssUrl" => $cssUrl,
+            "baseJsUrl" => $currentlyUsedJsUrl,
+            "baseCssUrl" => $currentlyusedCssUrl,
             "embedJsUrl" => $embedJsUrl,
             "signatureTimestamp" => $sts
         ];


### PR DESCRIPTION
This is using ANDROID for requests. Since Rehike's content restriction checks don't work on ANDROID player requests, they are disabled while using ANDROID player requests. 
It also requests the player storyboard with XBOXONEGUIDE. 
It always loads en_US player by default. The player files are also currently loaded from YouTube's servers.

In my own tests, there were zero fatal bugs, but please tell me if there are any. 