### PR TITLE
Make smallPlayer be part of LATEST, since it makes more sense

### DIFF
--- a/modules/Rehike/ConfigDefinitions.php
+++ b/modules/Rehike/ConfigDefinitions.php
@@ -56,6 +56,11 @@ class ConfigDefinitions
 								"RED",
 								"WHITE"
 							])
+                        ),
+					"smallPlayer" =>
+                        new DependentProp(
+                            "appearance.playerChoice == CURRENT",
+                            new BoolProp(false)
                         )
                 ]),
                 "modernLogo" => new BoolProp(true),
@@ -75,7 +80,6 @@ class ConfigDefinitions
                 "watchSidebarDates" => new BoolProp(false),
                 "watchSidebarVerification" => new BoolProp(false),
                 "oldBestOfYouTubeIcons" => new BoolProp(false),
-                "smallPlayer" => new BoolProp(true),
                 "enableAdblock" => new BoolProp(true)
             ],
             "experiments" => [


### PR DESCRIPTION
It doesn't make sense to apply the small button CSS to 2014, it would more likely break something. 
(I just noticed now that I accidentallly changed it from true to false, but should I even correct it, since we have 2020 player now anyway?)