### PR TITLE
Fix PHP 8.1 enum handling

### DIFF
--- a/includes/rehike_autoloader.php
+++ b/includes/rehike_autoloader.php
@@ -60,7 +60,7 @@ class Autoloader
                 \class_exists($class, false) ||
                 \interface_exists($class, false) ||
                 \trait_exists($class, false) ||
-                (PHP_VERSION_ID > 81000 && \enum_exists($class, false))
+                (PHP_VERSION_ID > 80100 && \enum_exists($class, false))
             )
             {
                 /*


### PR DESCRIPTION
This commit fixes two bugs relating to PHP 8.1 enum handling in Rehike library code.

The first bug fix is a simple typo correction in the autoloader. The wrong PHP version ID (81000 instead of 80100) was specified.

The second bug fix greatly changes RebugJsonEncodeManager. Because non-scalar-backed enums will cause json_encode() to error, I had to change the custom encoder to always shadow them, and this meant that I had to change how some optimizations work. Please review my changes.