### PR TITLE
Safe Twig i18n HTML interpolation implementation

### DIFF
--- a/modules/Rehike/TemplateUtilsDelegate/RehikeUtilsDelegateBase.php
+++ b/modules/Rehike/TemplateUtilsDelegate/RehikeUtilsDelegateBase.php
@@ -453,4 +453,12 @@ abstract class RehikeUtilsDelegateBase extends stdClass
     
         return Base64Url::encode($data);
     }
+
+    /**
+     * Marks a HTML string from Twig as safe HTML for interpolation.
+     */
+    public static function toSafeHtml(string $str): SafeHtml
+    {
+        return new SafeHtml($str);
+    }
 }

--- a/modules/Rehike/TemplateUtilsDelegate/RehikeUtilsI18nDelegate.php
+++ b/modules/Rehike/TemplateUtilsDelegate/RehikeUtilsI18nDelegate.php
@@ -4,6 +4,8 @@ namespace Rehike\TemplateUtilsDelegate;
 use Rehike\i18n\i18n;
 use Throwable;
 
+use Twig\Markup;
+
 /**
  * Internationalization engine delegate for use in Twig land.
  * 
@@ -33,6 +35,70 @@ class RehikeUtilsI18nDelegate
         catch (Throwable $e)
         {
             return "< unknown string $namespace:$name >";
+        }
+    }
+
+    public function formatHtml(string $namespace, string $name, mixed ...$args): Markup
+    {
+        try
+        {
+            $effectiveArgs = [];
+            $htmlSubstitutionTable = [];
+
+            foreach ($args as $arg)
+            {
+                $data = random_bytes(16);
+
+                // Set version to 0100 (UUID v4)
+                $data[6] = chr(ord($data[6]) & 0x0f | 0x40);
+                // Set bits 6-7 to 10 (variant)
+                $data[8] = chr(ord($data[8]) & 0x3f | 0x80);
+            
+                $guid = vsprintf(
+                    '%s%s-%s-%s-%s-%s%s%s', 
+                    str_split(bin2hex($data), 4)
+                );
+
+                if ($arg instanceof SafeHtml)
+                {
+                    $formattedGuid = "!!HTML--{$guid}!!";
+
+                    $htmlSubstitutionTable[] = [
+                        "html" => $arg->html,
+                        "guid" => $formattedGuid,
+                    ];
+
+                    $effectiveArgs[] = $formattedGuid;
+                }
+                else
+                {
+                    $effectiveArgs[] = $arg;
+                }
+            }
+
+            $result = htmlspecialchars(
+                i18n::getFormattedString($namespace, $name, ...$effectiveArgs),
+                \ENT_QUOTES | \ENT_SUBSTITUTE,
+                "UTF-8",
+            );
+
+            if (!empty($htmlSubstitutionTable))
+            {
+                foreach ($htmlSubstitutionTable as $entry)
+                {
+                    $result = str_replace(
+                        $entry["guid"],
+                        $entry["html"],
+                        $result
+                    );
+                }
+            }
+
+            return new Markup($result, "UTF-8");
+        }
+        catch (Throwable $e)
+        {
+            return new Markup("< unknown string $namespace:$name >", "UTF-8");
         }
     }
 

--- a/modules/Rehike/TemplateUtilsDelegate/SafeHtml.php
+++ b/modules/Rehike/TemplateUtilsDelegate/SafeHtml.php
@@ -1,0 +1,17 @@
+<?php
+namespace Rehike\TemplateUtilsDelegate;
+
+/**
+ * A wrapper class which denotes safe HTML input from Twig templates.
+ * 
+ * @author Pumpkin <pumpkinpielemon@gmail.com>
+ */
+class SafeHtml
+{
+    public string $html;
+
+    public function __construct(string $html)
+    {
+        $this->html = $html;
+    }
+}


### PR DESCRIPTION
This replaces the old strategy of trusting the entire localized string when HTML interpolation was required. Only arguments passed as SafeHtml objects are trusted as raw HTML strings and avoid escaping.

There was already an instance that I encountered of formatting being missed, albeit benign. Single quote characters should be escaped with the HTML entity "&#039;", but they weren't in the old case.

Because this is not compatible with format(), I added a new method to the i18n delegate. I don't know how to get the current Twig autoescaping strategy, and the function only escapes untrusted content as HTML. It could possibly be done with a Twig extension, but I think that's a bit overkill.

Additional details: For my project, I made a filter `safeHtml`. This is just `RehikeUtilsDelegateBase::toSafeHtml()` as a filter. For example, I wrote this:

```twig
<p>{{ app.i18n.formatHtml(
    "static_logged_out_homepage",
    "js_warn_body", link_html|safeHtml) }}</p>
```

Following this pull request, the following template can be modified to use this approach:

https://github.com/Rehike/Rehike/blob/77e6a872ba9fcc6cb9ffc6e7e72bb8b0e804994c/template/hitchhiker/rehike/version/credits.twig#L45-L52

This is the only part of the Rehike codebase that I can find that uses this pattern.