### PR TITLE
Option to change DNS server + Textboxes on GUI config editor

### DIFF
--- a/i18n/en-US/rehike/config.i18n
+++ b/i18n/en-US/rehike/config.i18n
@@ -136,6 +136,11 @@ props:
         (2023/08/18).
 
   advanced:
+    dnsAddress:
+      title: "DNS address for YouTube requests"
+      subtitle: >
+        Only change this value if you know what you're doing. An invalid value
+        will make all API requests fail.
     enableDebugger:
       title: "Enable the debugger"
       subtitle: >

--- a/i18n/es-LA/rehike/config.i18n
+++ b/i18n/es-LA/rehike/config.i18n
@@ -93,6 +93,11 @@ props:
         (2023/08/18).
   
   advanced:
+    dnsAddress:
+      title: "Dirección DNS para solicitudes de YouTube"
+      subtitle: >
+        Cambia este valor solo si sabes lo que estás haciendo.
+        Un valor no válido hará que todas las solicitudes de la API fallen.
     enableDebugger:
       title: "Habilita el depurador"
       subtitle: >

--- a/i18n/ja/rehike/config.i18n
+++ b/i18n/ja/rehike/config.i18n
@@ -134,6 +134,11 @@ props:
         ブロックする回避策です（2023/08/18）。
   
   advanced:
+    dnsAddress:
+      title: "YouTube リクエスト用の DNS アドレス"
+      subtitle: >
+        何をしているか理解している場合のみ、この値を変更してください。
+        無効な値を設定すると、すべての API リクエストが失敗します。
     enableDebugger:
       title: "デバッガーを有効化"
       subtitle: >

--- a/i18n/pt/rehike/config.i18n
+++ b/i18n/pt/rehike/config.i18n
@@ -139,6 +139,11 @@ props:
         (18/08/2023).
 
   advanced:
+    dnsAddress:
+      title: "Endereço DNS para solicitações do YouTube"
+      subtitle: >
+        Altere este valor apenas se souber o que está fazendo.
+        Um valor inválido fará com que todas as solicitações da API falhem.
     enableDebugger:
       title: "Ativar o debugger"
       subtitle: >

--- a/models/Rehike/Config/ConfigModelContents.php
+++ b/models/Rehike/Config/ConfigModelContents.php
@@ -9,7 +9,8 @@ use Rehike\ConfigManager\Properties\{
     DependentProp,
     BoolProp,
     EnumProp,
-    PropGroup
+    PropGroup,
+    StringProp,
 };
 use Rehike\i18n\i18n;
 
@@ -190,9 +191,19 @@ class ConfigModelContents
         {
             return $this->bakeBoolPropRenderer($params);
         }
+        else if ($prop instanceof StringProp)
+        {
+            return $this->bakeStringPropRenderer($params);
+        }
         else
         {
             // Unsupported.
+            trigger_error(
+                sprintf("Tried to render unsupported string property type %s",
+                    get_class($prop)
+                ),
+                E_USER_WARNING,
+            );
             return (object)[];
         }
     }
@@ -301,6 +312,43 @@ class ConfigModelContents
                 "name" => $params->path,
                 "values" => $values,
                 "selectedValue" => $selectedValue
+            ]
+        ];
+    }
+
+    /**
+     * textboxRenderer baker
+     */
+    private function bakeStringPropRenderer(AssociativePropParams $params): object
+    {
+        $i18n = $this->getI18nInfo($params->path);
+        $value = $this->getPropValue($params->path);
+
+        $title = $params->name;
+        if (isset($i18n->title))
+        {
+            $title = $i18n->title;
+        }
+
+        $subtitle = null;
+        if (isset($i18n->subtitle))
+        {
+            $subtitle = $i18n->subtitle;
+        }
+
+        /**
+         * @var StringProp
+         */
+        $propDef = $params->source;
+        $defaultValue = $propDef->getDefaultValue();
+
+        return (object) [
+            "textboxRenderer" => (object) [
+                "label" => $title,
+                "subtitle" => $subtitle,
+                "name" => $params->path,
+                "defaultValue" => $defaultValue,
+                "value" => $value,
             ]
         ];
     }

--- a/modules/Rehike/Boot/Bootloader.php
+++ b/modules/Rehike/Boot/Bootloader.php
@@ -174,9 +174,9 @@ final class Bootloader
      */
     private static function runInitTasks(): void
     {
+        Tasks::initConfigManager();
         Tasks::initNetwork();
         Tasks::initResourceConstants();
-        Tasks::initConfigManager();
     }
 
     /**

--- a/modules/Rehike/Boot/Tasks.php
+++ b/modules/Rehike/Boot/Tasks.php
@@ -35,8 +35,11 @@ final class Tasks
 {
     public static function initNetwork(): void
     {
+        $desiredDns = Config::getConfigProp("advanced.dnsAddress")
+            ?? "1.1.1.1";
+
         NetworkCore::setResolve([
-            Nameserver::get("www.youtube.com", "1.1.1.1", 443)->serialize()
+            Nameserver::get("www.youtube.com", $desiredDns, 443)->serialize()
         ]);
     }
 

--- a/modules/Rehike/ConfigDefinitions.php
+++ b/modules/Rehike/ConfigDefinitions.php
@@ -116,6 +116,7 @@ class ConfigDefinitions
                 ]),
             ],
             "advanced" => [
+                "dnsAddress" => new StringProp("1.1.1.1"),
                 "enableDebugger" => new BoolProp(false),
                 "developer" => [
                     "ignoreUnresolvedPromises" => new BoolProp(false)

--- a/modules/Rehike/Network.php
+++ b/modules/Rehike/Network.php
@@ -1,6 +1,7 @@
 <?php
 namespace Rehike;
 
+use Rehike\ConfigManager\Config;
 use Rehike\Exception\Network\InnertubeFailedRequestException;
 use Rehike\Signin\AuthManager;
 
@@ -29,8 +30,6 @@ class Network
     
     protected const V3_API_HOST = "https://www.googleapis.com";
     protected const V3_API_KEY = "AIzaSyAdXYhjVjFVmN4Txzxf0Lt3HS8FsxBPhSM"; // old key: "AIzaSyBeo4NGA__U6Xxy-aBE6yFm19pgq8TY-TM";
-
-    protected const DNS_OVERRIDE_HOST = "1.1.1.1";
 
     private static array $sessionRequestLog = [];
 
@@ -157,6 +156,9 @@ class Network
                  $requestHeaders,
                  $profilerRid)
         {
+            $desiredDns = Config::getConfigProp("advanced.dnsAddress")
+                ?? "1.1.1.1";
+
             NetworkCore::request(
                 "{$host}/youtubei/v1/{$action}?key={$key}",
                 [
@@ -164,7 +166,7 @@ class Network
                     "method" => "POST",
                     "body" => json_encode($body),
                     "onError" => "ignore",
-                    "dnsOverride" => self::DNS_OVERRIDE_HOST
+                    "dnsOverride" => $desiredDns,
                 ]
             )->then(function ($response) use ($resolve, $reject, $ignoreErrors, $profilerRid, $action) {
                 if ((200 == $response->status) || (true == $ignoreErrors) )
@@ -362,8 +364,11 @@ class Network
      */
     public static function getDefaultYoutubeOpts(): array
     {
+        $desiredDns = Config::getConfigProp("advanced.dnsAddress")
+                ?? "1.1.1.1";
+
         return [
-            "dnsOverride" => self::DNS_OVERRIDE_HOST,
+            "dnsOverride" => $desiredDns,
             "headers" => [
                 "Cookie" => self::getCurrentRequestCookie()
             ]

--- a/modules/Rehike/Util/Nameserver/Nameserver.php
+++ b/modules/Rehike/Util/Nameserver/Nameserver.php
@@ -66,10 +66,10 @@ class Nameserver
         // URI.
         $hostname = self::getHostName($uri);
 
-        $result = self::lookup($hostname, $port);
+        $result = self::lookup($hostname, $port, $nameserver);
         if (false == self::$gotFromCache)
         {
-            NameserverCache::write($result);
+            NameserverCache::write($nameserver, $result);
         }
         return $result;
     }
@@ -119,7 +119,7 @@ class Nameserver
             string $lookupServer
     ): NameserverInfo
     {
-        $cachedInfo = NameserverCache::get("$uri:$port");
+        $cachedInfo = NameserverCache::get($lookupServer, "$uri:$port");
 
         if (null === $cachedInfo)
         {

--- a/template/hitchhiker/rehike/config/js.twig
+++ b/template/hitchhiker/rehike/config/js.twig
@@ -55,6 +55,9 @@ rehike.config.init = function() {
     
     rehike.eventDelegate.add('change', 'rehike-config-option-enum',
         rehike.config.onModifyEnum_);
+    
+    rehike.eventDelegate.add('input', 'rehike-config-option-string',
+        rehike.config.onModifyString_);
 
     rehike.eventDelegate.add('click', 'rehike-config-save-button',
         rehike.config.submit_);
@@ -96,6 +99,21 @@ rehike.config.onModifyBool_ = function(prop) {
 rehike.config.onModifyEnum_ = function(prop) {
     var name = prop.getAttribute('data-cfg-name');
     var value = prop.querySelector('select').value;
+
+    rehike.config.modifyProp_(name, value);
+};
+
+/**
+ * Called whenever an string is modified.
+ * 
+ * @private
+ * 
+ * @param {Element} prop 
+ * @return {void}
+ */
+rehike.config.onModifyString_ = function(prop) {
+    var name = prop.getAttribute('data-cfg-name');
+    var value = prop.querySelector('input').value;
 
     rehike.config.modifyProp_(name, value);
 };

--- a/template/hitchhiker/rehike/config/main.twig
+++ b/template/hitchhiker/rehike/config/main.twig
@@ -50,11 +50,35 @@
     </span>
 {% endmacro %}
 
+{% macro textbox_renderer(this) %}
+    <label>
+        {{ this.label }}
+        <span class="{{ [
+                'rehike-config-option',
+                'rehike-config-option-string',
+                'yt-uix-form-input-text-container',
+            ]|join(' ') }}" data-cfg-name="{{ this.name }}"
+            data-original-value="{{ this.value }}">
+            <input class="yt-uix-form-input-text" 
+                type="text"
+                placeholder="{{ this.defaultValue }}"
+                value="{{ this.value }}">
+        </span>
+        {% if this.subtitle %}
+            <p class="setting-reminder">
+                {{ this.subtitle }}
+            </p>
+        {% endif %}
+    </label>
+{% endmacro %}
+
 {% macro try_render_associative_prop(option) %}
     {% if option.checkboxRenderer %}
         {{ _self.checkbox_renderer(option.checkboxRenderer) }}
     {% elseif option.selectRenderer %}
         {{ _self.select_renderer(option.selectRenderer) }}
+    {% elseif option.textboxRenderer %}
+        {{ _self.textbox_renderer(option.textboxRenderer) }}
     {% elseif option.dependentPropertyRenderer %}
         {% set this = option.dependentPropertyRenderer %}
         <div class="dependent-property" data-condition="{{ this.condition }}">


### PR DESCRIPTION
I added some additional code to improve the UX of this change, such as support for textboxes to modify string configuration properties.

Alongside general reasons (i.e. the user may not wish to use Cloudflare DNS for personal reasons), this also helps improve the reliability of Rehike in some countries (Russia, China, Iran) where access to Cloudflare's services may be limited.